### PR TITLE
SDC-2502 Update Microsite for New sdc.dot.gov URL

### DIFF
--- a/banner.html
+++ b/banner.html
@@ -91,7 +91,7 @@
         <li class="usa-nav__primary-item"> <a class="usa-nav__link" href="https://github.com/usdot-jpo-sdc" target="_blank"><span>GitHub Project</span> <img src="assets/img/external-link.svg" alt="external link" class="usa-header__primary-link-icon-social"></a> </li>
         <li class="usa-nav__primary-item">
           <div class="display-flex flex-column">
-            <a class="login_button usa-button" href="https://portal.securedatacommons.com/register">Login</a>
+            <a class="login_button usa-button" href="https://portal.sdc.dot.gov/register">Login</a>
             <a class="accessLink" href="files/SDCAccessRequestForm.pdf" target="_blank">Request Access</a>
           </div>
         </li>

--- a/login.html
+++ b/login.html
@@ -46,7 +46,7 @@
             <label class="usa-checkbox__label" for="statement-agreement">I agree to the statements above.</label>
           </div>
   
-          <button class="usa-button" id="proceed-button" onclick="window.location.href = 'https://portal.securedatacommons.com/register'" disabled>Proceed to Log In</button>
+          <button class="usa-button" id="proceed-button" onclick="window.location.href = 'https://portal.sdc.dot.gov/register'" disabled>Proceed to Log In</button>
         
           <div class="version-history">Last updated with release 2.5 (February 6, 2020)</div>
 

--- a/request_access.html
+++ b/request_access.html
@@ -121,7 +121,7 @@
             <label class="usa-checkbox__label" for="term-agreement">I agree to the terms and conditions of the SDC and USDOT for using the SDC platform.</label>
           </div>
 
-          <button class="usa-button" id="proceed-button" onclick="window.location.href = 'https://portal.securedatacommons.com/register'" disabled>Proceed to Log In</button>
+          <button class="usa-button" id="proceed-button" onclick="window.location.href = 'https://portal.sdc.dot.gov/register'" disabled>Proceed to Log In</button>
           <div class="version-history">Last updated with release 2.5 (February 6, 2020)</div>
 
         </div>


### PR DESCRIPTION
Notes:
- I can't find the references to portal.sdc.dot.gov when I preview banner.html, so I wasn't able to test that.
- I assumed that the usernames for the email stayed the same between securedatacommons.com and sdc.dot.gov.

