### PR TITLE
Change SDC support email address from support@securedatacommons.com t…

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ The Secure Data Commons (SDC) is a cloud-based analytics platform that enables a
 <a name="release-notes"/>
 
 ## I. Release Notes
+<strong>August 21, 2020. SDC sdc-dot-web-microsite Release 2.7</strong><br/>
+What's New in Release 2.7:
+- Change SDC support email address from support@securedatacommons.com to sdc-support@dot.gov
+
 <strong>July 23, 2020. SDC sdc-dot-web-microsite Release 2.6.2</strong><br/>
 What's New in Release 2.6.2:
 - Link on https://its.dot.gov/data/secure/ “login” button will go straight to dot.gov vs .com
@@ -194,7 +198,7 @@ August 8, 2019. SDC sdc-dot-web-microsite Release 2.1<br/>
 Distributed under the XYZ license. See LICENSE for more information.
 https://github.com/yourname/github-link -->
 
-For any queries you can reach to support@securedatacommons.com
+For any queries you can reach to sdc-support@dot.gov
 
 
 <!---                           -->
@@ -242,7 +246,7 @@ Tags: transportation, connected vehicles, intelligent transportation systems
 
 Labor Hours:
 
-Contact Name: support@securedatacommons.com
+Contact Name: sdc-support@dot.gov
 
 <!-- Contact Phone: -->
 

--- a/conducting_analysis.html
+++ b/conducting_analysis.html
@@ -172,7 +172,7 @@
                 <p class="margin-top-2">
                   <a href="files/SDCAccessRequestForm.pdf" target="_blank">Download the access request form (PDF 77 KB)</a>, 
                   fill out the required details, and send an email to 
-                  <a href="mailto:support@securedatacommons.com">support<br>@securedatacommons.com</a>. 
+                  <a href="mailto:sdc-support@dot.gov">sdc-support<br>@dot.gov</a>. 
                   Once approved, we will send you an email with the instructions for accessing the platform.
                 </p>
               </div>

--- a/enablement_services_program.html
+++ b/enablement_services_program.html
@@ -155,7 +155,7 @@
         <h2 class="margin-top-6">Available Program Offerings</h2>
         <p>See more information about each program offering below.</p> 
         <p>Contact the SDC team to get a quote, upgrade or change your services. If you are an independent analyst not on a project team, email us to find out how the offerings can work for you. </p>
-        <a class="usa-button margin-top-3 flex-justify-center display-flex desktop:display-inline-block" href="mailto:support@securedatacommons.com">Email SDC Team</a>
+        <a class="usa-button margin-top-3 flex-justify-center display-flex desktop:display-inline-block" href="mailto:sdc-support@dot.gov">Email SDC Team</a>
       
         <hr class="margin-y-6 border-base-lightest" />
 

--- a/getting_data_to_sdc.html
+++ b/getting_data_to_sdc.html
@@ -161,7 +161,7 @@
                   <img src="images/svgs/SDC_Icon_Number1.svg" alt="Number one">
                 </div>
                 <p class="margin-top-2">
-                  <a href="mailto:support@securedatacommons.com">Contact the SDC team</a> 
+                  <a href="mailto:sdc-support@dot.gov">Contact the SDC team</a> 
                   for a discovery meeting. Let&apos;s discuss data restrictions, agreements, and user&apos;s access level to your data within the SDC.
                   Review the <a target="_blank" href="files/Secure_Data_Commons_Data_Provider_User_Guide.pdf">Data Provider User Guide (PDF 709 KB)</a>.
                 </p>

--- a/support.html
+++ b/support.html
@@ -48,7 +48,7 @@
         <a target="_blank" href="files/Secure_Data_Commons_Data_Analyst_User_Guide.pdf">User Guide for Data Analysts (PDF 4.8 MB)</a>
         <h3>Data Provider Training Materials</h3>
         <a target="_blank" href="files/Secure_Data_Commons_Data_Provider_User_Guide.pdf">User Guide for Data Providers (PDF 709 KB)</a>
-        <h4>For more videos and more information about the SDC please reach out to the <a href="mailto:support@securedatacommons.com">SDC Support Desk</a>.</h4>
+        <h4>For more videos and more information about the SDC please reach out to the <a href="mailto:sdc-support@dot.gov">SDC Support Desk</a>.</h4>
           
         <div class="version-history">Last updated with release 2.5 (February 6, 2020)</div>
         </div>

--- a/what_you_need_to_know.html
+++ b/what_you_need_to_know.html
@@ -134,7 +134,7 @@
             <p>
               Currently the SDC is available only to USDOT-approved projects. If you are a part of a current SDC project and would like access,
               or if you would like to propose your project as a new applicant for the SDC,
-              please email <a href="mailto:support@securedatacommons.com">support@securedatacommons.com</a>.
+              please email <a href="mailto:sdc-support@dot.gov">sdc-support@dot.gov</a>.
             </p>
           </div>
         </div>


### PR DESCRIPTION
…o sdc-support@dot.gov

SDC-2772: As an SDC Data Analyst, I want to send my questions to a “dot.gov” email so that I am assured I am interacting with an official DoT site.